### PR TITLE
v1.0.0

### DIFF
--- a/src/AspNetCoreSubdomain/AspNetCoreSubdomain.csproj
+++ b/src/AspNetCoreSubdomain/AspNetCoreSubdomain.csproj
@@ -2,13 +2,14 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>0.5.0</Version>
+    <Version>1.0.0</Version>
     <Authors>Mariusz Kerl</Authors>
     <Company />
     <Description>Create subdomain routes like default route semantics, build subdomain links with helpers.</Description>
     <PackageTags>web mvc aspnet core routing subdomain</PackageTags>
     <PackageReleaseNotes>
-    Defaults in subdomain template are now supported
+    Library is now in .NET Standard 2.0
+    Removed SubdomainLink html helper extensions. Standard HtmlAction has to be used instead.
     </PackageReleaseNotes>
     <AssemblyVersion>0.0.0.1</AssemblyVersion>
     <FileVersion>0.0.0.1</FileVersion>


### PR DESCRIPTION
Library is now in .NET Standard 2.0
Removed SubdomainLink html helper extensions. Standard HtmlAction has to be used instead.